### PR TITLE
Conntrack-sync events over UDP

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vyatta-conntrack-sync (0.46+vyos2+current2) unstable; urgency=low
+
+  * Added UDP synchronization.
+
+ -- Alexander Verhaar <sanderv32@gmail.com>  Sat, 12 Mar 2016 01:24:07 +0100
+
 vyatta-conntrack-sync (0.46+vyos2+current1) unstable; urgency=medium
 
   [ Thomas Jepp ]

--- a/debian/vyatta-conntrack-sync.substvars
+++ b/debian/vyatta-conntrack-sync.substvars
@@ -1,0 +1,1 @@
+misc:Depends=

--- a/lib/Vyatta/ConntrackSync.pm
+++ b/lib/Vyatta/ConntrackSync.pm
@@ -196,6 +196,7 @@ sub generate_conntrackd_config {
   my @iponly = split( '/', $intf_ip[0] );
   my $mcast_grp = get_conntracksync_val( "returnValue", "mcast-group" );
   my $peer = get_conntracksync_val( "returnValue", "interface $intf_name[0] peer" );
+  my $listenon = get_conntracksync_val( "returnValue", "listen-address" );
 
   my $conntrack_table_size = `cat /proc/sys/net/netfilter/nf_conntrack_max`;
   my $cache_hash_size      = `cat /sys/module/nf_conntrack/parameters/hashsize`;
@@ -244,14 +245,15 @@ sub generate_conntrackd_config {
 
   if ( $peer ) {
     $output .= $UNICAST_SECTION_START;
-    $output .= "\t\tIPv4_address $peer\n";
-    $output .= "\t\tGroup 3781\n";
+    $output .= "\t\tIPv4_address $listenon\n" if (defined $listenon);
+    $output .= "\t\tIPv4_Destination_Address $peer\n";
+    $output .= "\t\tPort 3780\n";
   } else {
     $output .= $MULTICAST_SECTION_START;
     $output .= "\t\tIPv4_address $mcast_grp\n";
     $output .= "\t\tGroup 3780\n";
+    $output .= "\t\tIPv4_interface $iponly[0]\n";
   }
-  $output .= "\t\tIPv4_interface $iponly[0]\n";
   $output .= "\t\tInterface $intf_name[0]\n";
   $output .= "\t\tSndSocketBuffer $sync_queue_size\n";
   $output .= "\t\tRcvSocketBuffer $sync_queue_size\n";

--- a/lib/Vyatta/ConntrackSync.pm
+++ b/lib/Vyatta/ConntrackSync.pm
@@ -60,6 +60,7 @@ my $GENERAL_SECTION_START    = "General {\n";
 my $SYNC_SECTION_START       = "Sync {\n";
 my $MODE_SECTION_START       = "\tMode FTFW {\n";
 my $MULTICAST_SECTION_START  = "\tMulticast {\n";
+my $UNICAST_SECTION_START    = "\tUDP {\n";
 my $OPTIONS_SECTION_START    = "\tOptions {\n";
 my $OPTIONS_EXPECTATIONSYNC_START    = "\t\tExpectationSync {\n";
 
@@ -190,10 +191,11 @@ sub generate_conntrackd_config {
   my $expect_all_flag = 'false';
   my $expect_sync_configured = 'false';
   
-  my $intf_name = get_conntracksync_val( "returnValue", "interface" );
-  my @intf_ip = Vyatta::Misc::getIP( $intf_name, '4' );
+  my @intf_name = get_conntracksync_val( "listNodes", "interface" );
+  my @intf_ip = Vyatta::Misc::getIP( $intf_name[0], '4' );
   my @iponly = split( '/', $intf_ip[0] );
   my $mcast_grp = get_conntracksync_val( "returnValue", "mcast-group" );
+  my $peer = get_conntracksync_val( "returnValue", "interface $intf_name[0] peer" );
 
   my $conntrack_table_size = `cat /proc/sys/net/netfilter/nf_conntrack_max`;
   my $cache_hash_size      = `cat /sys/module/nf_conntrack/parameters/hashsize`;
@@ -240,15 +242,20 @@ sub generate_conntrackd_config {
   # mode section end
   $output .= "\t$SECTION_END";
 
-  $output .= $MULTICAST_SECTION_START;
-  $output .= "\t\tIPv4_address $mcast_grp\n";
-  $output .= "\t\tGroup 3780\n";
+  if ( $peer ) {
+    $output .= $UNICAST_SECTION_START;
+    $output .= "\t\tIPv4_address $peer\n";
+    $output .= "\t\tGroup 3781\n";
+  } else {
+    $output .= $MULTICAST_SECTION_START;
+    $output .= "\t\tIPv4_address $mcast_grp\n";
+    $output .= "\t\tGroup 3780\n";
+  }
   $output .= "\t\tIPv4_interface $iponly[0]\n";
-  $output .= "\t\tInterface $intf_name\n";
+  $output .= "\t\tInterface $intf_name[0]\n";
   $output .= "\t\tSndSocketBuffer $sync_queue_size\n";
   $output .= "\t\tRcvSocketBuffer $sync_queue_size\n";
   $output .= "\t\tChecksum on\n";
-  # multicast section end
   $output .= "\t$SECTION_END";
 
   # If any expect-sync protocolis configured, write options section
@@ -358,15 +365,15 @@ sub interface_checks {
   my $err_string = undef;
 
   # make sure interface is defined
-  my $intf_name = get_conntracksync_val( "returnValue", "interface" );
-  if ( !defined $intf_name ) {
+  my @intf_name = get_conntracksync_val( "listNodes", "interface" );
+  if ( scalar(@intf_name) == 0 ) {
     $err_string = "$CONNTRACKSYNC_ERR_STRING interface not defined";
     return $err_string;
   }
 
   # also need to validate that interface exists on the system
   # and that it has an IP address assigned to it
-  my $intf = new Vyatta::Interface($intf_name);
+  my $intf = new Vyatta::Interface($intf_name[0]);
   if ($intf) {
     if ( !$intf->exists() ) {
       $err_string = "$CONNTRACKSYNC_ERR_STRING interface does not exist on system";

--- a/scripts/vyatta-op-conntrack-sync.pl
+++ b/scripts/vyatta-op-conntrack-sync.pl
@@ -33,13 +33,13 @@ use strict;
 my $FAILOVER_STATE_FILE = '/var/run/vyatta-conntrackd-failover-state';
 
 sub is_conntracksync_configured {
-  my $conntrack_sync_intf = get_conntracksync_val('returnOrigValue', 'interface');
-  return "conntrack-sync not configured" if ! defined $conntrack_sync_intf;
+  my @conntrack_sync_intf = get_conntracksync_val('listOrigNodes', 'interface');
+  return "conntrack-sync not configured" if ( scalar(@conntrack_sync_intf) == 0);
   return;
 }
 sub is_expectsync_configured {
-  my $conntrack_sync_intf = get_conntracksync_val('returnOrigValue', 'interface');
-  return "conntrack-sync not configured" if ! defined $conntrack_sync_intf;
+  my @conntrack_sync_intf = get_conntracksync_val('listOrigNodes', 'interface');
+  return "conntrack-sync not configured" if ( scalar(@conntrack_sync_intf) == 0);
 
   my @expect_sync_protocols = 
       get_conntracksync_val("returnOrigValues", "expect-sync");
@@ -54,7 +54,7 @@ sub ctsync_status {
 
   my @failover_mechanism =
     get_conntracksync_val( "listOrigNodes", "failover-mechanism" );
-  my $ct_sync_intf = get_conntracksync_val( "returnOrigValue", "interface" );
+  my @ct_sync_intf = get_conntracksync_val( "listOrigNodes", "interface" );
 
   my $cluster_grp = undef;
   my $vrrp_sync_grp = undef;
@@ -86,7 +86,7 @@ sub ctsync_status {
       }
   }
   print "\n";
-  print "sync-interface        : $ct_sync_intf\n";
+  print "sync-interface        : $ct_sync_intf[0]\n";
   print "failover-mechanism    : $failover_mechanism[0]";
   print " [group $cluster_grp]\n" if $failover_mechanism[0] eq 'cluster';
   print " [sync-group $vrrp_sync_grp]\n" if $failover_mechanism[0] eq 'vrrp';

--- a/templates-cfg/service/conntrack-sync/interface/node.def
+++ b/templates-cfg/service/conntrack-sync/interface/node.def
@@ -1,5 +1,4 @@
+tag:
 type: txt
-
 help: Interface to use for syncing conntrack entries [REQUIRED]
-
 allowed: ${vyatta_sbindir}/vyatta-interfaces.pl --show all

--- a/templates-cfg/service/conntrack-sync/interface/node.tag/peer/node.def
+++ b/templates-cfg/service/conntrack-sync/interface/node.tag/peer/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: IP address of the peer to send the UDP conntrack info too. This disable multicast.

--- a/templates-cfg/service/conntrack-sync/listen-address/node.def
+++ b/templates-cfg/service/conntrack-sync/listen-address/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: IP to listen for syncing conntrack entries


### PR DESCRIPTION
Hi,

Added peer address in the interface section to allow syncing over UDP instead of multicast. Also added listen-address so that you can specify on which IP conntrackd should listen for events.
