### PR TITLE
Allow conntrackd to sync via unicast

### DIFF
--- a/templates-cfg/service/conntrack-sync/sync-method/node.def
+++ b/templates-cfg/service/conntrack-sync/sync-method/node.def
@@ -1,0 +1,7 @@
+type: txt
+default: "multicast"
+help: Method to use for syncing states
+val_help: multicast; Use multicast for conntrack-sync (default)
+val_help: unicast; Use unicast for conntrack-sync
+syntax:expression: pattern $VAR(@) "^(multicast|unicast)$" ; \
+"Invalid value for sync-protocol. Allowed values: multicast unicast"

--- a/templates-cfg/service/conntrack-sync/udp-destination-address/node.def
+++ b/templates-cfg/service/conntrack-sync/udp-destination-address/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: IPv4 address of remote node (UNICAST ONLY:REQURIED)

--- a/templates-cfg/service/conntrack-sync/udp-listen-address/node.def
+++ b/templates-cfg/service/conntrack-sync/udp-listen-address/node.def
@@ -1,0 +1,2 @@
+type: ipv4
+help: IPv4 address this router will use to listen for events (UNICAST ONLY:REQURIED)


### PR DESCRIPTION
This is to address high CPU usage when using multicast on a busy firewall
